### PR TITLE
Fix missing includes in same folder from bower

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function customImporter(url, prev, done) {
 		var result = findInParentDirSync(url, prev);
 		return complete(result, done);
 	} else {
-		return complete(url, done);
+		return null;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var sass = require('node-sass'),
-	path = require('path'),
+var path = require('path'),
 	fs = require('fs'),
 	resolve = require('resolve');
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function customImporter(url, prev, done) {
 		var result = findInParentDirSync(url, prev);
 		return complete(result, done);
 	} else {
-		return sass.NULL;
+		return complete(url, done);
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frau-sass-importer",
-  "version": "0.3.1",
+  "version": "0.2.0",
   "description": "Custom importer for node-sass to help resolve paths to node modules and bower components.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frau-sass-importer",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "description": "Custom importer for node-sass to help resolve paths to node modules and bower components.",
   "main": "index.js",
   "scripts": {

--- a/tests/index.js
+++ b/tests/index.js
@@ -2,7 +2,6 @@
 
 var chai = require('chai'),
 	expect = chai.expect,
-	sass = require('node-sass'),
 	path = require('path'),
 	mockFs = require('mock-fs'),
 	fs = require('fs'),

--- a/tests/index.js
+++ b/tests/index.js
@@ -24,7 +24,7 @@ describe('Custom importer', function() {
 					expect.fail();
 				});
 
-				expect(result).to.equal(sass.NULL);
+				expect(result).to.equal(null);
 			});
 
 			it('should ignore relative path starting with an unhandled base folder name that cannot be resolved', function() {
@@ -35,7 +35,7 @@ describe('Custom importer', function() {
 					expect.fail();
 				});
 
-				expect(result).to.equal(sass.NULL);
+				expect(result).to.equal(null);
 			});
 
 			it('should ignore absolute path that canont be resolved', function() {
@@ -46,7 +46,7 @@ describe('Custom importer', function() {
 					expect.fail();
 				});
 
-				expect(result).to.equal(sass.NULL);
+				expect(result).to.equal(null);
 			});
 
 			it('should return an error when a node_modules path cannot be found', function(done) {
@@ -214,7 +214,7 @@ describe('Custom importer', function() {
 					prev = '/parent/file/parent.scss';
 
 				var result = importer(url, prev);
-				expect(result).to.equal(sass.NULL);
+				expect(result).to.equal(null);
 			});
 
 			it('should ignore relative path starting with an unhandled base folder name that cannot be resolved', function() {
@@ -222,7 +222,7 @@ describe('Custom importer', function() {
 					prev = '/parent/file/parent.scss';
 
 				var result = importer(url, prev);
-				expect(result).to.equal(sass.NULL);
+				expect(result).to.equal(null);
 			});
 
 			it('should ignore absolute path that canont be resolved', function() {
@@ -230,7 +230,7 @@ describe('Custom importer', function() {
 					prev = '/parent/file/parent.scss';
 
 				var result = importer(url, prev);
-				expect(result).to.equal(sass.NULL);
+				expect(result).to.equal(null);
 			});
 
 			it('should return an error when a node_modules path cannot be found', function() {


### PR DESCRIPTION
Fixes missing mixins when including files from the same folder, installed via bower.

For example:
https://github.com/Brightspace/valence-ui-input/blob/b489b90ccda718598a5934564ec783347fae7514/input-checkbox.scss#L1

Causes the following error:
```
{
  "status": 1,
  "file": "C:/d2l/instances/lsone2/checkout/awards-ui/bower_components/vui-input/input-checkbox.scss",
  "line": 6,
  "column": 11,
  "message": "no mixin named -vui-input-checkbox-radio-helper
   Backtrace:
   bower_components/vui-input/input-checkbox.scss:6, in mixin `vui-input-checkbox`\n\tsrc/app.scss:47",
  "formatted": "Error: no mixin named -vui-input-checkbox-radio-helper
       Backtrace:
        bower_components/vui-input/input-checkbox.scss:6, in mixin `vui-input-checkbox`
        src/app.scss:47 on line 6 of bower_components/vui-input/input-checkbox.scss
        >> @include _vui-input-checkbox-radio-helper(
----------^"
}
```

With:
` node-sass --importer ./node_modules/sass-module-importer/ ./src/app.scss > ./dist/importstyles.css`